### PR TITLE
Upgrade okdata-aws to lose vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile
 #
-annotated-types==0.5.0
-    # via pydantic
 anyio==4.0.0
     # via starlette
 attrs==23.1.0
@@ -15,7 +13,9 @@ attrs==23.1.0
 aws-xray-sdk==2.12.0
     # via okdata-data-uploader (setup.py)
 boto3==1.28.49
-    # via okdata-data-uploader (setup.py)
+    # via
+    #   okdata-aws
+    #   okdata-data-uploader (setup.py)
 botocore==1.31.49
     # via
     #   aws-xray-sdk
@@ -23,12 +23,14 @@ botocore==1.31.49
     #   s3transfer
 certifi==2023.7.22
     # via requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==3.2.0
     # via requests
+cryptography==42.0.5
+    # via jwcrypto
 deprecation==2.1.0
     # via python-keycloak
-ecdsa==0.18.0
-    # via python-jose
 idna==3.7
     # via
     #   anyio
@@ -43,31 +45,21 @@ jsonschema==4.19.0
     #   okdata-sdk
 jsonschema-specifications==2023.7.1
     # via jsonschema
-okdata-aws==1.0.1
+jwcrypto==1.5.6
+    # via python-keycloak
+okdata-aws==4.1.0
     # via okdata-data-uploader (setup.py)
 okdata-resource-auth==0.1.4
     # via okdata-data-uploader (setup.py)
-okdata-sdk==2.4.1
+okdata-sdk==3.1.1
     # via okdata-aws
 packaging==23.1
     # via deprecation
-pyasn1==0.5.0
-    # via
-    #   python-jose
-    #   rsa
-pydantic==2.4.0
-    # via okdata-aws
-pydantic-core==2.10.0
-    # via pydantic
-pyjwt==2.8.0
-    # via okdata-sdk
+pycparser==2.22
+    # via cffi
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
-    # via
-    #   okdata-sdk
-    #   python-keycloak
-python-keycloak==3.3.0
+python-keycloak==3.12.0
     # via okdata-sdk
 referencing==0.30.2
     # via
@@ -87,27 +79,22 @@ rpds-py==0.10.3
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via python-jose
 s3transfer==0.6.2
     # via boto3
 six==1.16.0
-    # via
-    #   ecdsa
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.3.0
     # via anyio
-starlette==0.36.2
+starlette==0.37.2
     # via okdata-aws
 structlog==23.1.0
     # via okdata-aws
 typing-extensions==4.8.0
-    # via
-    #   pydantic
-    #   pydantic-core
+    # via jwcrypto
 urllib3==1.26.18
     # via
     #   botocore
+    #   okdata-sdk
     #   requests
 wrapt==1.15.0
     # via aws-xray-sdk

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "aws-xray-sdk",
         "jsonschema",
         "requests",
-        "okdata-aws",
+        "okdata-aws>=4.1",
         "okdata-resource-auth",
     ],
 )


### PR DESCRIPTION
Remove dependency on the vulnerable ecdsa library by upgrading okdata-aws.