### PR TITLE
Revert "Allow upload for datasets with source type `api`"

### DIFF
--- a/tests/test_generate_signed_post.py
+++ b/tests/test_generate_signed_post.py
@@ -142,17 +142,14 @@ def test_handler_invalid_source_type(api_gateway_event, requests_mock):
     response = handler(event, None)
     assert response["statusCode"] == 400
     assert json.loads(response["body"]) == {
-        "message": "Invalid source.type 'database' for dataset: datasetid"
+        "message": "Invalid source.type 'database' for dataset: datasetid. Must be source.type='file'"
     }
 
 
 @freeze_time("2020-11-02T19:54:14.123456+00:00")
-@pytest.mark.parametrize("source_type", ["file", "api"])
-def test_handler(api_gateway_event, requests_mock, source_type):
+def test_handler(api_gateway_event, requests_mock):
     url = "https://api.data-dev.oslo.systems/metadata/datasets/datasetid"
-    response = json.dumps(
-        {"accessRights": "restricted", "source": {"type": source_type}}
-    )
+    response = json.dumps({"accessRights": "restricted", "source": {"type": "file"}})
     requests_mock.register_uri("GET", url, text=response, status_code=200)
 
     url = "https://api.data-dev.oslo.systems/metadata/datasets/datasetid/versions/1/editions/20190101T125959"

--- a/uploader/common.py
+++ b/uploader/common.py
@@ -92,8 +92,8 @@ def get_and_validate_dataset(dataset_id):
     dataset = response.json()
     source_type = dataset["source"]["type"]
 
-    if source_type not in ["file", "api"]:
-        error_msg = f"Invalid source.type '{source_type}' for dataset: {dataset_id}"
+    if source_type != "file":
+        error_msg = f"Invalid source.type '{source_type}' for dataset: {dataset_id}. Must be source.type='file'"
         raise InvalidSourceTypeError(error_msg)
 
     return dataset


### PR DESCRIPTION
This reverts commit 2420fd548f5ee6e958829b0e8fde5c4b3d07b3f7. We are now instead relying on [another dataset metadata property](https://github.com/oslokommune/okdata-metadata-api/pull/73).