### PR TITLE
Add option to merge event data

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,12 +1,10 @@
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
 
-from uploader.dataset import (
-    append_to_dataset,
-    dataframe_from_dict,
-)
-from uploader.errors import InvalidTypeError
+from uploader.dataset import add_to_dataset, dataframe_from_dict
+from uploader.errors import InvalidTypeError, MissingMergeColumnsError
 
 
 @pytest.mark.parametrize(
@@ -78,7 +76,7 @@ def test_dataframe_from_dict(data, schema):
         ([{"a": 1}], []),
     ],
 )
-def test_append_to_dataset(
+def test_add_to_dataset(
     temp_dir,
     mocked_wr_read_deltalake,
     existing_data,
@@ -91,9 +89,114 @@ def test_append_to_dataset(
         ]
     ).reset_index(drop=True)
 
-    merged_df = append_to_dataset("s3://foo/bar", new_data)
+    merged_df = add_to_dataset("s3://foo/bar", new_data)
 
     assert merged_df.equals(target_df)
+
+
+@pytest.mark.parametrize(
+    "existing_data,new_data,expected_result",
+    [
+        (
+            [{"id": 1, "data": 1}],
+            [{"id": 2, "data": 2}],
+            [{"id": 1, "data": 1}, {"id": 2, "data": 2}],
+        ),
+        (
+            [{"id": 1}],
+            [{"id": 2, "data": 1}],
+            [{"id": 1, "data": np.nan}, {"id": 2, "data": 1}],
+        ),
+        (
+            [{"id": 1, "data": 1}],
+            [{"id": 2}],
+            [{"id": 1, "data": 1}, {"id": 2, "data": np.nan}],
+        ),
+        (
+            [{"id": 1, "data": "override-me"}, {"id": 2, "data": "keep-me"}],
+            [{"id": 1, "data": "overridden"}, {"id": 3, "data": "foo"}],
+            [
+                {"id": 1, "data": "overridden"},
+                {"id": 2, "data": "keep-me"},
+                {"id": 3, "data": "foo"},
+            ],
+        ),
+        (
+            [{"id": 1, "data": 1}, {"id": 1, "data": 2}],
+            [{"id": 1, "data": 5}, {"id": 3, "data": 3}],
+            # Results in duplicates
+            [{"id": 1, "data": 5}, {"id": 1, "data": 5}, {"id": 3, "data": 3}],
+        ),
+    ],
+)
+def test_merge_on_single_column(
+    temp_dir,
+    mocked_wr_read_deltalake,
+    existing_data,
+    new_data,
+    expected_result,
+):
+    merged_df = add_to_dataset("s3://foo/bar", new_data, ["id"])
+
+    pd.testing.assert_frame_equal(
+        merged_df,
+        pd.DataFrame.from_dict(expected_result).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "existing_data,new_data",
+    [
+        ([{"data": 1}], [{"id": 1, "data": 2}]),
+        ([{"id": 1, "data": 1}], [{"data": 2}]),
+        ([{"data": 1}], [{"data": 2}]),
+        ([{"id": 1, "data": 1}], [{"id": None, "data": 2}]),
+        ([{"id": None, "data": 1}], [{"id": 1, "data": 2}]),
+        ([{"id": None, "data": 1}], [{"id": None, "data": 2}]),
+    ],
+)
+def test_merge_with_missing_merge_column(
+    temp_dir, mocked_wr_read_deltalake, existing_data, new_data
+):
+    with pytest.raises(MissingMergeColumnsError):
+        add_to_dataset("s3://foo/bar", new_data, ["id"])
+
+
+@pytest.mark.parametrize(
+    "existing_data,new_data,expected_result",
+    [
+        (
+            [
+                {"id1": 0, "id2": 0, "data": "zero", "data2": "zero"},
+                {"id1": 1, "id2": 1, "data": "foo", "data2": "keep-me"},
+            ],
+            [
+                {"id1": 1, "id2": 1, "data": "bar"},
+                {"id1": 1, "id2": 2, "data": "bax"},
+            ],
+            [
+                {"id1": 0, "id2": 0, "data": "zero", "data2": "zero"},
+                {"id1": 1, "id2": 1, "data": "bar", "data2": "keep-me"},
+                {"id1": 1, "id2": 2, "data": "bax", "data2": pd.NA},
+            ],
+        )
+    ],
+)
+def test_merge_on_multiple_column(
+    temp_dir,
+    mocked_wr_read_deltalake,
+    existing_data,
+    new_data,
+    expected_result,
+):
+    merged_df = add_to_dataset("s3://foo/bar", new_data, ["id1", "id2"])
+
+    pd.testing.assert_frame_equal(
+        merged_df,
+        pd.DataFrame.from_dict(expected_result).reset_index(drop=True),
+        check_dtype=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -103,10 +206,10 @@ def test_append_to_dataset(
         ([{"invalid_column": "2024-10-22T14:43:31.012588"}], [{"invalid_column": "-"}]),
     ],
 )
-def test_append_to_dataset_mixed_types(
+def test_add_to_dataset_mixed_types(
     mocked_wr_read_deltalake,
     existing_data,
     new_data,
 ):
     with pytest.raises(InvalidTypeError, match=r"invalid_column"):
-        append_to_dataset("s3://foo/bar", new_data)
+        add_to_dataset("s3://foo/bar", new_data)

--- a/uploader/dataset.py
+++ b/uploader/dataset.py
@@ -3,28 +3,49 @@ import pandas as pd
 import pyarrow as pa
 from deltalake.exceptions import TableNotFoundError
 
-from uploader.errors import InvalidTypeError
+from uploader.errors import InvalidTypeError, MissingMergeColumnsError
 
 
-def append_to_dataset(s3_path, data):
+def add_to_dataset(s3_path, data, merge_on=[]):
+    """Return the dataset found at `s3_path` with `data` added to it.
+
+    `merge_on` is a list of column names to optionally merge ("full join" in
+    the SQL world) the data on. New data overrides old data on conflicting
+    rows.
+
+    If `merge_on` is empty, the new data is simply appended to the existing
+    dataset.
+    """
     # Create DataFrame with new data
     events = dataframe_from_dict(data)
 
-    # Load existing dataset contents to DataFrame and concatenate new objects. If
-    # the dataset is empty, new data is written directly.
+    # Load existing dataset contents to DataFrame and add new objects. If the
+    # dataset is empty, new data is written directly.
     try:
         existing_dataset = wr.s3.read_deltalake(
             s3_path,
             dtype_backend="pyarrow",
         )
-        merged_data = pd.concat([existing_dataset, events])
+        if merge_on:
+            try:
+                events.set_index(merge_on, inplace=True)
+                existing_dataset.set_index(merge_on, inplace=True)
+            except KeyError as e:
+                raise MissingMergeColumnsError(f"Missing ID column(s): {e}")
+            # A note on efficiency: Local tests suggest that this should scale
+            # well to at least tens of millions of rows.
+            merged_data = events.combine_first(existing_dataset)
+            # Turn the index back into ordinary columns
+            merged_data.reset_index(inplace=True)
+        else:
+            merged_data = pd.concat([existing_dataset, events])
     except TableNotFoundError:
         merged_data = events
 
     # Ensure that we have no index
     merged_data = merged_data.reset_index(drop=True)
 
-    # Ensure no columns contains mixed types
+    # Ensure no columns contain mixed types
     mixed_columns = [c for c in merged_data if merged_data[c].dtype == "object"]
 
     if mixed_columns:

--- a/uploader/errors.py
+++ b/uploader/errors.py
@@ -16,3 +16,7 @@ class DatasetNotFoundError(Exception):
 
 class InvalidTypeError(Exception):
     pass
+
+
+class MissingMergeColumnsError(Exception):
+    pass

--- a/uploader/handlers/push_dataset_events.py
+++ b/uploader/handlers/push_dataset_events.py
@@ -18,11 +18,12 @@ from uploader.common import (
     get_and_validate_dataset,
     sdk_config,
 )
-from uploader.dataset import append_to_dataset
+from uploader.dataset import add_to_dataset
 from uploader.errors import (
-    InvalidSourceTypeError,
     DatasetNotFoundError,
+    InvalidSourceTypeError,
     InvalidTypeError,
+    MissingMergeColumnsError,
 )
 from uploader.schema import get_model_schema
 
@@ -34,10 +35,10 @@ LOCK_RETRIES = 5
 resource_authorizer = ResourceAuthorizer()
 
 
-def _handle_events(dataset, version, source_s3_path, events):
+def _handle_events(dataset, version, merge_on, source_s3_path, events):
     dataset_id = dataset["Id"]
 
-    merged_data = append_to_dataset(source_s3_path, events)
+    merged_data = add_to_dataset(source_s3_path, events, merge_on)
     sdk = Dataset(sdk_config())
     edition = sdk.auto_create_edition(dataset_id, version)
 
@@ -103,10 +104,12 @@ def handler(event, context):
         body = json.loads(event["body"])
         validate(body, get_model_schema("pushEventsRequest"))
         dataset_id = body["datasetId"]
+        merge_on = body.get("mergeOn", [])
         version = body.get("version", "1")
 
         log_add(
             dataset_id=dataset_id,
+            merge_on=merge_on,
             dataset_version=version,
             event_count=len(body["events"]),
         )
@@ -162,7 +165,7 @@ def handler(event, context):
             )
             locked = True
             edition_id = _handle_events(
-                dataset, version, source_s3_path, body["events"]
+                dataset, version, merge_on, source_s3_path, body["events"]
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
@@ -173,6 +176,9 @@ def handler(event, context):
         except InvalidTypeError as e:
             log_add(exc_info=e)
             return error_response(400, str(e))
+        except MissingMergeColumnsError as e:
+            log_add(exc_info=e)
+            return error_response(422, str(e))
         finally:
             if locked:
                 lock_table.delete_item(Key={"DatasetId": dataset_id})


### PR DESCRIPTION
Add a new optional parameter `mergeOn` to the data events endpoint which specifies a set of columns to merge old and new data on.

This makes it possible to achieve idempotence on the endpoint by specifying ID columns in `mergeOn`.

It also enables updating data in previously added rows.