### PR TITLE
Sprinkle on some more logging

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -98,7 +98,7 @@ functions:
       name: okdata-data-uploader
       command:
         - uploader.handlers.push_dataset_events.handler
-    timeout: 30
+    timeout: 40
     events:
       - http:
           path: /events


### PR DESCRIPTION
Let's log a bit more to try to find the culprit causing the event data Lambda function to time out occasionally.

Also log the duration of some of the suspected heaviest function calls to learn more about where the Lambda is spending most of its time.