### PR TITLE
Bump data handler Lambda memory some more

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,7 +100,7 @@ functions:
       name: okdata-data-uploader
       command:
         - uploader.handlers.push_dataset_events.handler
-    memorySize: 4096
+    memorySize: 8192
     timeout: 30
     events:
       - http:
@@ -138,7 +138,7 @@ functions:
       name: okdata-data-uploader
       command:
         - uploader.handlers.handle_queue.event_queue_handler
-    memorySize: 4096
+    memorySize: 8192
     timeout: 40
     events:
       - sqs:


### PR DESCRIPTION
After the `mergeOn` field has been taken in use, our memory demands have increased even more. Bump it again.